### PR TITLE
Fix pre-commit config bug

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,14 +12,9 @@ repos:
     hooks:
       - id: ruff
         name: Lint with Ruff
-        language: system
-        entry: ruff check --force-exclude --fix
-        types: [python]
-        require_serial: true
+        args: [ --fix ]
+        types: [ python ]
 
       - id: ruff-format
         name: Format with Ruff
-        language: system
-        entry: ruff format --force-exclude
-        types: [python]
-        require_serial: true
+        types: [ python ]


### PR DESCRIPTION
Don't require local Ruff installation for pre-commit hooks.  Really really this time.