### PR TITLE
Add software citation information and DOI badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,12 +36,12 @@ bioRxiv 2025.04.16.648720; doi: https://doi.org/10.1101/2025.04.16.648720
 
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.15274840.svg)](https://doi.org/10.5281/zenodo.15274840)
 
-Releases of this software are archived on Zenodo.  If you use ANARCII in your
+Releases of this software are [archived on Zenodo](https://doi.org/10.5281/zenodo.15274840).  If you use ANARCII in your
 work, please cite the paper.  If you additionally want to cite the software
-specifically, [this DOI always resolves to the Zenodo record for the latest
-version](https://doi.org/10.5281/zenodo.15274840):
+specifically, this DOI always resolves to the Zenodo record for the latest
+version:
 
 <https://doi.org/10.5281/zenodo.15274840>
 
 If you want to cite a specific version, Zenodo provides individual DOIs for
-each, which you can find via the main Zenodo record.
+each, which you can find via the above link to the main record.

--- a/README.md
+++ b/README.md
@@ -1,26 +1,47 @@
 # ANARCII
 
-For the user guide please read the Wiki page: 
+ANARCII is a generalised language model for antigen receptor numbering.
 
-https://github.com/oxpig/ANARCII/wiki
+For the user guide please read the [wiki page](https://github.com/oxpig/ANARCII/wiki).
 
+## Web tool
 
+We have a live [web tool](https://opig.stats.ox.ac.uk/webapps/sabdab-sabpred/sabpred/anarcii/):
 
-## Citing this work 
-All code is based on the following paper: 
+<https://opig.stats.ox.ac.uk/webapps/sabdab-sabpred/sabpred/anarcii/>
+
+If you use this code or the web tool in your work, please [cite the paper](#the-paper).
+
+## Citing this work
+
+### The paper
+
+[![DOI](https://zenodo.org/badge/DOI/10.1101/2025.04.16.648720.svg)](https://doi.org/10.1101/2025.04.16.648720)
+
+All code is based on the following paper:
 
 *ANARCII: A Generalised Language Model for Antigen Receptor Numbering*
 
-https://www.biorxiv.org/content/10.1101/2025.04.16.648720v1
+<https://www.biorxiv.org/content/10.1101/2025.04.16.648720v1>
 
-We have a live webtool:
-
-https://opig.stats.ox.ac.uk/webapps/sabdab-sabpred/sabpred/anarcii/
-
-If you use this code or the webtool in your work, please cite:
+Please cite:
 
 ```
 ANARCII: A Generalised Language Model for Antigen Receptor Numbering
 Alexander Greenshields-Watson, Parth Agarwal, Sarah A Robinson, Benjamin Heathcote Williams, Gemma L Gordon, Henriette L Capel, Yushi Li, Fabian C Spoendlin, Fergus Boyles, Charlotte M Deane
 bioRxiv 2025.04.16.648720; doi: https://doi.org/10.1101/2025.04.16.648720 
 ```
+
+### The software
+
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.15274840.svg)](https://doi.org/10.5281/zenodo.15274840)
+
+Releases of this software are archived on Zenodo.  If you use ANARCII in your
+work, please cite the paper.  If you additionally want to cite the software
+specifically, [this DOI always resolves to the Zenodo record for the latest
+version](https://doi.org/10.5281/zenodo.15274840):
+
+<https://doi.org/10.5281/zenodo.15274840>
+
+If you want to cite a specific version, Zenodo provides individual DOIs for
+each, which you can find via the main Zenodo record.

--- a/README.md
+++ b/README.md
@@ -36,10 +36,10 @@ bioRxiv 2025.04.16.648720; doi: https://doi.org/10.1101/2025.04.16.648720
 
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.15274840.svg)](https://doi.org/10.5281/zenodo.15274840)
 
-Releases of this software are [archived on Zenodo](https://doi.org/10.5281/zenodo.15274840).  If you use ANARCII in your
-work, please cite the paper.  If you additionally want to cite the software
-specifically, this DOI always resolves to the Zenodo record for the latest
-version:
+Releases of this software are [archived on Zenodo](https://doi.org/10.5281/zenodo.15274840).
+If you use ANARCII in your work, please [cite the paper](#the-paper).  If you
+also want to cite the software specifically, this DOI always resolves to the
+Zenodo record for the latest version:
 
 <https://doi.org/10.5281/zenodo.15274840>
 


### PR DESCRIPTION
ANARCII releases are [archived on Zenodo](https://doi.org/10.5281/zenodo.15274840).  Point users to this, in case they are interested in citing specific software versions specifically, but emphasise that we request that they always cite the paper at least.

Also, add pretty DOI badges for the paper and for the main Zenodo record.