### PR TITLE
CLI changes, allow for vhh/vnar/shark and fix to_msgpack scheme None

### DIFF
--- a/src/anarcii/inference/model_loader.py
+++ b/src/anarcii/inference/model_loader.py
@@ -30,7 +30,7 @@ class Loader:
         self.model = self._load_model()
 
     def _load_params(self):
-        if self.type == "shark":
+        if self.type in ["shark", "vhh", "vnar"]:
             param_filename = f"{self.type}_4_2_128_512.json"
         elif self.mode == "speed":
             param_filename = f"{self.type}_4_1_128_512.json"
@@ -39,7 +39,7 @@ class Loader:
         else:
             raise ValueError(
                 "Invalid mode specified. Choose either 'speed' or 'accuracy' or "
-                "'shark'."
+                "'shark/vnar/vhh'."
             )
 
         param_path = pkg_resources.files("anarcii.models").joinpath(

--- a/src/anarcii/inference/model_runner.py
+++ b/src/anarcii/inference/model_runner.py
@@ -47,7 +47,7 @@ class ModelRunner:
         self.device = device
         self.verbose = verbose
 
-        if self.type in ["antibody", "shark"]:
+        if self.type in ["antibody", "shark", "vhh", "vnar"]:
             self.sequence_tokeniser = NumberingTokeniser("protein_antibody")
             self.number_tokeniser = NumberingTokeniser("number_antibody")
 

--- a/src/anarcii/inference/window_selector.py
+++ b/src/anarcii/inference/window_selector.py
@@ -48,7 +48,7 @@ class WindowFinder:
         self.batch_size = batch_size
         self.device = device
 
-        if self.type in ["antibody", "shark"]:
+        if self.type in ["antibody", "shark", "vhh", "vnar"]:
             self.sequence_tokeniser = NumberingTokeniser("protein_antibody")
             self.number_tokeniser = NumberingTokeniser("number_antibody")
 

--- a/src/anarcii/pipeline/__init__.py
+++ b/src/anarcii/pipeline/__init__.py
@@ -337,7 +337,8 @@ class Anarcii:
             else:
                 to_msgpack(last_object, file_path)
                 print(
-                    f"Last output saved to {file_path} in scheme: {self._alt_scheme}."
+                    f"Last output saved to {file_path} in scheme: "
+                    f"{self._alt_scheme or 'imgt'}."
                 )
 
     def to_csv(self, file_path):


### PR DESCRIPTION
Resolves #91 
Resolves #89 
Resolves #78 

* CLI multiple options for alt number schemes and max_seqs_len.
* CLI needs to explain that --cpu is a standalone flag not needing True/False.
* Users must be able to use the fine-tuned shark/vnar/vhh model by any of these identifiers.
* The method to save MessagePack files, to_msgpack, should say IMGT not None.