### PR TITLE
SCFV Mode Issues Fix: Error on null sequences and incorrect sort order

### DIFF
--- a/notebook/scfv_testing.ipynb
+++ b/notebook/scfv_testing.ipynb
@@ -2,15 +2,13 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "The autoreload extension is already loaded. To reload it, use:\n",
-      "  %reload_ext autoreload\n",
       "Using device CUDA with 12 CPUs\n",
       "Length of the sequence: 849\n",
       "Found more than 2 domains for Sequence.\n",
@@ -86,7 +84,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [
     {
@@ -122,7 +120,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
@@ -2429,7 +2427,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.0"
+   "version": "3.13.2"
   }
  },
  "nbformat": 4,

--- a/src/anarcii/input_data_processing/sequences.py
+++ b/src/anarcii/input_data_processing/sequences.py
@@ -164,8 +164,6 @@ class SequenceProcessor:
                     data = data[start_idx + SHIFT :]
                     last_start += start_idx + SHIFT
 
-                    continue
-
                 # Found windows >>> modify the seqs dict (still works for non SCFVs)
                 # Remove the original key if it already exists
                 seq = self.seqs[key]

--- a/src/anarcii/input_data_processing/sequences.py
+++ b/src/anarcii/input_data_processing/sequences.py
@@ -164,12 +164,8 @@ class SequenceProcessor:
                     data = data[start_idx + SHIFT :]
                     last_start += start_idx + SHIFT
 
-                # Found windows >>> modify the seqs dict (still works for non SCFVs)
-                # Remove the original key if it already exists
+                # Get the original sequence.
                 seq = self.seqs[key]
-
-                self.offsets.pop(key, None)
-                self.seqs.pop(key, None)
 
                 ### NOW LOOK FOR PEAKS (> threshold & within 50 residues of minima).
                 offset = 0
@@ -205,8 +201,15 @@ class SequenceProcessor:
                                 )  # increment by 180 aa
                             ]
 
+                        # Found window > modify seqs dict (works for non SCFVs)
+                        # Remove the original key if it already exists
+                        # None ensures no error.
+                        self.offsets.pop(key, None)
+                        self.seqs.pop(key, None)
+
                         self.offsets[new_key] = peak_idx_plus2 * SCFV_JUMP
                         self.seqs[new_key] = window
+
                         if self.verbose:
                             print(
                                 f"Identified potential domain. Renamed to: {new_key}\n",
@@ -221,6 +224,11 @@ class SequenceProcessor:
                     print(f"Only found 1 domain for {key}.\n")
                 elif found == 0:
                     print(f"Failed to find any domain for {key}.\n")
+                    # The sequence will not be broken up - just remove
+                    # This ensure it is not processed further.
+                    self.offsets[key] = 0
+                    self.seqs[key] = ""
+
                 elif found > 2:
                     print(f"Found more than 2 domains for {key}.\n")
 

--- a/src/anarcii/input_data_processing/sequences.py
+++ b/src/anarcii/input_data_processing/sequences.py
@@ -225,7 +225,7 @@ class SequenceProcessor:
                 elif found == 0:
                     print(f"Failed to find any domain for {key}.\n")
                     # The sequence will not be broken up - just remove
-                    # This ensure it is not processed further.
+                    # This ensures it is not processed further.
                     self.offsets[key] = 0
                     self.seqs[key] = ""
 

--- a/src/anarcii/pipeline/__init__.py
+++ b/src/anarcii/pipeline/__init__.py
@@ -188,6 +188,7 @@ class Anarcii:
 
         for i, chunk in enumerate(batched(seqs.items(), self.max_seqs_len), 1):
             chunk = dict(chunk)
+            original_keys = list(chunk)
 
             if self.verbose:
                 print(f"Processing chunk {i} of {n_chunks}.")
@@ -211,7 +212,24 @@ class Anarcii:
                 numbered = self.number_with_type(chunk, self.seq_type, scfv)
 
             # Restore the original input order to the numbered sequences.
-            numbered = {key: numbered[key] for key in chunk}
+            # If SCFV has been run then the keys will have been modified to
+            # include the linker, so we cannot do this.
+            if not scfv:
+                numbered = {key: numbered[key] for key in original_keys}
+            else:
+                new_keys = list(numbered)
+
+                tmp_dt = {}
+                for x in original_keys:
+                    for y in new_keys:
+                        if y.startswith(x):
+                            tmp_dt[x] = tmp_dt.get(x, []) + [y]
+                tmp_dt = {k: sorted(v) for k, v in tmp_dt.items()}
+
+                # Pull out all the values
+                ordered_new_keys = [sv for _, v in tmp_dt.items() for sv in v]
+                # Now reorder numbered dict
+                numbered = {key: numbered[key] for key in ordered_new_keys}
 
             # If the sequences came from a PDB(x) file, renumber them in the associated
             # data structure.


### PR DESCRIPTION
Fixes #107 

* Rearrange where the original key is popped when multiple domains are found, avoid key error.
* Ensure that sequences with no domains are not processed further.
* Function to ensure that sort order in SCFV mode is preserved to original dict input.